### PR TITLE
[Hunterize] Add support for installs, with a project config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # cmake -DCMAKE_BUILD_TYPE=Debug ..
 # cmake -DCMAKE_BUILD_TYPE=Release ..
-cmake_minimum_required(VERSION 2.8)
-project(bento4)
+cmake_minimum_required(VERSION 3.0.2)
+project(bento4 LANGUAGES CXX VERSION "0.0.0")
 
 # Variables
 set(SOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Source/C++)
@@ -26,6 +26,12 @@ file(GLOB AP4_SOURCES
   ${SOURCE_METADATA}/*.cpp
   ${SOURCE_SYSTEM}/StdC/*.cpp
 )
+file(GLOB AP4_HEADERS
+  ${SOURCE_CORE}/*.h
+  ${SOURCE_CODECS}/*.h
+  ${SOURCE_CRYPTO}/*.h
+  ${SOURCE_METADATA}/*.h
+)
 
 if(WIN32)
   set(AP4_SOURCES ${AP4_SOURCES} ${SOURCE_SYSTEM}/Win32/Ap4Win32Random.cpp)
@@ -36,17 +42,74 @@ endif()
 add_library(ap4 STATIC ${AP4_SOURCES})
 
 # Includes
-include_directories(
+list(APPEND BENTO4_INCLUDE_DIRS
   ${SOURCE_CORE}
   ${SOURCE_CODECS}
   ${SOURCE_CRYPTO}
   ${SOURCE_METADATA}
+)
+target_include_directories(
+  ap4
+  PUBLIC
+  "$<BUILD_INTERFACE:${BENTO4_INCLUDE_DIRS}>"
 )
 
 # Apps
 file(GLOB BENTO4_APPS RELATIVE ${SOURCE_ROOT}/Apps ${SOURCE_ROOT}/Apps/*)
 foreach(app ${BENTO4_APPS})
   string(TOLOWER ${app} binary_name)
+  list(APPEND BENTO4_APPS_LOWERCASE ${binary_name})
   add_executable(${binary_name} ${SOURCE_ROOT}/Apps/${app}/${app}.cpp)
   target_link_libraries(${binary_name} ap4)
 endforeach()
+
+# Introduce variables:
+# * CMAKE_INSTALL_LIBDIR
+# * CMAKE_INSTALL_BINDIR
+# * CMAKE_INSTALL_INCLUDEDIR
+include(GNUInstallDirs)
+
+set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+
+set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(NAMESPACE "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${VERSION_CONFIG}" COMPATIBILITY ExactVersion
+)
+
+configure_package_config_file(
+  "cmake/Config.cmake.in"
+  "${PROJECT_CONFIG}"
+  INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+install(
+  TARGETS ap4 ${BENTO4_APPS_LOWERCASE}
+  EXPORT "${TARGETS_EXPORT_NAME}"
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)
+
+install(
+  FILES ${AP4_HEADERS}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+)
+
+install(
+  FILES "${PROJECT_CONFIG}" "${VERSION_CONFIG}"
+  DESTINATION "${CONFIG_INSTALL_DIR}"
+)
+
+install(
+  EXPORT "${TARGETS_EXPORT_NAME}"
+  NAMESPACE "${NAMESPACE}"
+  DESTINATION "${CONFIG_INSTALL_DIR}"
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,16 @@
+# Copyright (c) 2016, Ruslan Baratov
+#
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
This change enhances the CMake script to support installing the package so that other projects can use it.

- This adds support for a config file. This is the conventional way for a cmake project to support use by other projects via cmake [find_package](https://cmake.org/cmake/help/latest/command/find_package.html). See https://gitlab.kitware.com/cmake/community/wikis/doc/tutorials/How-to-create-a-ProjectConfig.cmake-file for more information.
- This adds support for an install target. You can then run `make install`, and it will install the static library and headers for other projects to consume, the generated config files, and the binaries for all of the apps in the project. The install locations are conventional (`/usr/local/{include|bin|lib}`) but can be overriden by the consuming package, or a package manager.

I've tested the basic ability to build against the include directory and link against the static library, and be able to use the library from another project.

This is also sufficient for use with package managers like https://docs.hunter.sh/en/latest/index.html.

PTAL @barbibulle 